### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical GitHub workflows and collaboration skills",
+        "schedule": "One-time workshop, Date TBD",
+        "max_participants": 50,
+        "participants": []
     }
 }
 

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+from src.app import app
+
+client = TestClient(app)
+
+
+def test_github_skills_present():
+    res = client.get("/activities")
+    assert res.status_code == 200
+    activities = res.json()
+    assert "GitHub Skills" in activities
+
+
+def test_signup_for_github_skills():
+    email = "test_student@mergington.edu"
+    # Ensure signup works
+    res = client.post(f"/activities/GitHub Skills/signup?email={email}")
+    assert res.status_code == 200
+    assert "Signed up" in res.json()["message"]
+
+    # Verify the participant was added
+    res = client.get("/activities")
+    activities = res.json()
+    assert email in activities["GitHub Skills"]["participants"]


### PR DESCRIPTION
Adds a new activity "GitHub Skills" to the in-memory activities list and adds tests to verify it appears and that signup works.